### PR TITLE
Simplify Mosh scheme-script command

### DIFF
--- a/mosh/0.2.x/Dockerfile
+++ b/mosh/0.2.x/Dockerfile
@@ -49,4 +49,4 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
   && rm -rf /var/lib/apt/lists/*
 COPY --from=build /usr/local/share/ /usr/local/share/
 COPY --from=build /usr/local/bin/ /usr/local/bin/
-COPY scheme-script /usr/local/bin
+RUN ln -s mosh /usr/local/bin/scheme-script

--- a/mosh/0.2.x/scheme-script
+++ b/mosh/0.2.x/scheme-script
@@ -1,4 +1,0 @@
-#!/bin/sh
-script="$1"
-shift
-exec /usr/local/bin/mosh "$script" "$@"


### PR DESCRIPTION
It's identical to just calling "mosh" so a symlink should be enough.