### PR TITLE
Upgrade to IronScheme 1.0.125 and fix banner

### DIFF
--- a/ironscheme/Dockerfile
+++ b/ironscheme/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
        xz-utils \
   && rm -rf /var/lib/apt/lists/*
 
-ADD https://github.com/leppie/IronScheme/releases/download/1.0.123/IronScheme-1.0.123-11d458e.zip IronScheme.zip
+ADD https://github.com/leppie/IronScheme/releases/download/1.0.125/IronScheme-1.0.125-21ecbfd.zip IronScheme.zip
 RUN unzip IronScheme.zip && mv IronScheme /usr/local
 
 FROM debian:buster-slim
@@ -18,5 +18,8 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
   && rm -rf /var/lib/apt/lists/*
 ENV LANG C.UTF-8
 COPY ironscheme /usr/local/bin/
-RUN ln -s ironscheme /usr/local/bin/scheme-script
-CMD ["ironscheme"]
+RUN ln -s IronScheme.Console-v4.exe /usr/local/IronScheme/ironscheme && \
+    ln -s ironscheme /usr/local/bin/isc && \
+    ln -s ironscheme /usr/local/bin/scheme-banner && \
+    ln -s ironscheme /usr/local/bin/scheme-script
+CMD ["scheme-banner"]

--- a/ironscheme/ironscheme
+++ b/ironscheme/ironscheme
@@ -3,10 +3,14 @@
 set -eu
 
 pathflags=()
-IFS=':' read -ra paths <<< "${IRONSCHEME_LIBRARY_PATH:-}"
+IFS=':' read -ra paths <<<"${IRONSCHEME_LIBRARY_PATH:-}"
 for path in "${paths[@]}"; do
   pathflags+=(-I "$path")
 done
 
-exec mono /usr/local/IronScheme/IronScheme.Console-v4.exe \
-  /nologo -- "${pathflags[@]}" "$@"
+command=ironscheme
+case $(basename "$0") in
+scheme-banner) command=IronScheme.Console-v4.exe ;;
+esac
+
+exec mono "/usr/local/IronScheme/$command" -- "${pathflags[@]}" "$@"


### PR DESCRIPTION
```
$ docker run -it ironscheme
IronScheme 1.0.125-21ecbfd github.com/leppie/IronScheme © 2007-2016 Llewellyn Pritchard (.NET 4.0 64-bit)
> (+ 1 2 3 4)
10
> (exit)

$ docker run -it ironscheme bash
root@35052c92c2c0:/# isc
> (+ 1 2 3 4)
10
> (exit)
root@35052c92c2c0:/# ironscheme
> (+ 1 2 3 4)
10
> (exit)
root@35052c92c2c0:/# scheme-banner
IronScheme 1.0.125-21ecbfd github.com/leppie/IronScheme © 2007-2016 Llewellyn Pritchard (.NET 4.0 64-bit)
> (+ 1 2 3 4)
10
> (exit)
root@35052c92c2c0:/# cat >hello.scm
#! /usr/bin/env scheme-script
(import (rnrs))
(display "Hello world")
(newline)
root@35052c92c2c0:/# chmod +x hello.scm
root@35052c92c2c0:/# ./hello.scm
Hello world
root@35052c92c2c0:/# echo $?
0
root@35052c92c2c0:/# exit
```