### PR TITLE
Pull latest official release tarball and build it

### DIFF
--- a/gauche/0.9.x/Dockerfile
+++ b/gauche/0.9.x/Dockerfile
@@ -1,9 +1,17 @@
 # -*- mode: dockerfile; coding: utf-8 -*-
 FROM debian:buster-slim AS build
-RUN apt-get update && apt-get -y --no-install-recommends install \
-       gauche \
-  && rm -rf /var/lib/apt/lists/*
-
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+        libtool pkg-config curl ca-certificates unzip netbase \
+        openssh-client zlib1g-dev \
+    && mkdir /home/gauche \
+    && cd /home/gauche \
+    && curl https://raw.githubusercontent.com/shirok/get-gauche/master/get-gauche.sh > get-gauche.sh \
+    && chmod +x get-gauche.sh \
+    && ./get-gauche.sh --prefix /usr/local --version latest --auto \
+    && apt-get remove -y --purge --auto-remove build-essential \
+        libtool pkg-config curl unzip \
+    && rm -rf /var/lib/apt/lists/*
 COPY scheme-banner /usr/local/bin/
 RUN ln -s gosh /usr/bin/scheme-r7rs
 CMD ["scheme-banner"]


### PR DESCRIPTION
This Dockerfile takes the latest Gauche release tarball and build it then install.

Pros - you can always catch up to the new releases

Cons - Docker image is now 220MB, from 89MB when you use just Debian gauche package.

