### PR TITLE
Build Gauche in a separate container

### DIFF
--- a/gauche/0.9.x/Dockerfile
+++ b/gauche/0.9.x/Dockerfile
@@ -12,6 +12,9 @@ RUN apt-get update \
     && apt-get remove -y --purge --auto-remove build-essential \
         libtool pkg-config curl unzip \
     && rm -rf /var/lib/apt/lists/*
+
+FROM debian:buster-slim
+COPY --from=build /usr/local/ /usr/local/
 COPY scheme-banner /usr/local/bin/
 RUN ln -s gosh /usr/bin/scheme-r7rs
 CMD ["scheme-banner"]


### PR DESCRIPTION
Reduces the final Gauche container's size from 220 to 190 MB.